### PR TITLE
Add an optional Receipt Required guard to destructive row deletion tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
-  "name": "@mcp-servers/baserow",
+  "name": "@ayyazzafar/mcp-baserow",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@mcp-servers/baserow",
+      "name": "@ayyazzafar/mcp-baserow",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@emilia-protocol/require-receipt": "^0.3.0",
         "@modelcontextprotocol/sdk": "^1.0.4",
         "axios": "^1.7.9",
         "dotenv": "^16.4.7"
@@ -19,6 +20,15 @@
       },
       "engines": {
         "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@emilia-protocol/require-receipt": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@emilia-protocol/require-receipt/-/require-receipt-0.3.0.tgz",
+      "integrity": "sha512-uvYFxfek1qnVI4oIKwlBDps7+Pj58npHpeS8MB+FhE6t7IVpdHodE9Z99yg/Wtscr0qiSGSLs0/b7jridMMcsw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@emilia-protocol/require-receipt": "^0.3.0",
+        "@emilia-protocol/require-receipt": "^0.4.0",
         "@modelcontextprotocol/sdk": "^1.0.4",
         "axios": "^1.7.9",
         "dotenv": "^16.4.7"
@@ -23,9 +23,9 @@
       }
     },
     "node_modules/@emilia-protocol/require-receipt": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@emilia-protocol/require-receipt/-/require-receipt-0.3.0.tgz",
-      "integrity": "sha512-uvYFxfek1qnVI4oIKwlBDps7+Pj58npHpeS8MB+FhE6t7IVpdHodE9Z99yg/Wtscr0qiSGSLs0/b7jridMMcsw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emilia-protocol/require-receipt/-/require-receipt-0.4.0.tgz",
+      "integrity": "sha512-ECl95tEF3LFPAfXyQb1BrcvoRF/oVXyu4TKAsFGE2g3axnuFoOpvio5Y6KgObajWqi2sevmrU8MEcDd04DFWdg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "homepage": "https://github.com/ayyazzafar/mcp-baserow#readme",
   "dependencies": {
+    "@emilia-protocol/require-receipt": "^0.3.0",
     "@modelcontextprotocol/sdk": "^1.0.4",
     "axios": "^1.7.9",
     "dotenv": "^16.4.7"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/ayyazzafar/mcp-baserow#readme",
   "dependencies": {
-    "@emilia-protocol/require-receipt": "^0.3.0",
+    "@emilia-protocol/require-receipt": "^0.4.0",
     "@modelcontextprotocol/sdk": "^1.0.4",
     "axios": "^1.7.9",
     "dotenv": "^16.4.7"

--- a/src/receipt-guard.ts
+++ b/src/receipt-guard.ts
@@ -1,7 +1,4 @@
-import type {
-  VerifyResult,
-  ChallengeOptions
-} from '@emilia-protocol/require-receipt';
+import type { ReceiptGate, RunResult } from '@emilia-protocol/require-receipt';
 
 // @emilia-protocol/require-receipt is ESM-only while this server compiles to
 // CommonJS, so load it via a real dynamic import() that tsc won't downlevel to
@@ -20,88 +17,64 @@ function loadModule(): Promise<RequireReceiptModule> {
   return modulePromise;
 }
 
-// One-time consumption: receipt_ids consumed by this process cannot be replayed.
-const consumedReceiptIds = new Set<string>();
-
-export type GuardResult =
-  | { ok: true; receiptId: string; commit: () => void }
-  | { ok: false; challenge: Record<string, unknown> };
+// All the hardening (per-target binding, verify, replay refusal, consume-after-
+// success, sanitized {reason} rejections) now lives in the canonical
+// makeReceiptGate. This file just builds one gate per irreversible action — each
+// `action` is a function so the EXACT bound action string is derived here — and
+// caches it across the async module load. NOTE: allowInlineKey accepts the
+// receipt's own key (proves integrity, not trust); in production pin trustedKeys
+// to the issuers you trust and drop allowInlineKey.
+const gates = new Map<string, Promise<ReceiptGate>>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getGate(key: string, action: (target: any) => string): Promise<ReceiptGate> {
+  let gate = gates.get(key);
+  if (!gate) {
+    gate = loadModule().then(({ makeReceiptGate }) =>
+      makeReceiptGate({ action, allowInlineKey: true, maxAgeSec: 900 })
+    );
+    gates.set(key, gate);
+  }
+  return gate;
+}
 
 /**
- * Demand a verifiable EMILIA authorization receipt before an irreversible action.
- *
- * On success, returns the receipt id PLUS a `commit()` callback. The receipt is
- * NOT marked consumed until the caller invokes `commit()` — which the caller MUST
- * do only AFTER the irreversible action has actually succeeded. If the action
- * throws, `commit()` is never called and the approval stays retryable (it was
- * never spent on a delete that didn't happen). Replay protection is enforced at
- * verify time (not-already-consumed check below), so a receipt can never drive
- * two deletes even before commit.
- *
- * On failure, returns a machine-readable Receipt Required challenge (HTTP 428
- * shape) the agent can act on — the MCP tool-result equivalent of answering 428.
- * Rejection detail is sanitized to a minimal `{ rejected: { reason } }` shape so
- * no signer, subject, or library internals leak to the caller. This is portable
- * accountability evidence the service keeps for its own liability; it is not auth
- * or permissions.
+ * Demand a verifiable EMILIA authorization receipt for a single-row delete,
+ * bound to THIS exact table + row: a receipt approving `baserow.row.delete:5:11`
+ * cannot delete row 99. gate.run verifies+reserves, runs `fn`, then consumes the
+ * receipt only AFTER it succeeds — if `fn` throws the approval is released (stays
+ * retryable) and the error propagates. Replay is refused; a verification failure
+ * returns a sanitized Receipt Required challenge ({ rejected: { reason } }).
  */
-export async function guardReceipt(
-  action: string,
-  receipt: unknown
-): Promise<GuardResult> {
-  const { verifyEmiliaReceipt, receiptChallenge, RECEIPT_REQUIRED_STATUS } =
-    await loadModule();
+export async function runDeleteRowGuarded(
+  tableId: number | string,
+  rowId: number | string,
+  receipt: unknown,
+  fn: () => Promise<void>
+): Promise<RunResult> {
+  const gate = await getGate(
+    'delete_row',
+    (t: { tableId: unknown; rowId: unknown }) => `baserow.row.delete:${t.tableId}:${t.rowId}`
+  );
+  return gate.run(receipt, { target: { tableId, rowId } }, fn);
+}
 
-  const challengeOpts: ChallengeOptions = {
-    status: RECEIPT_REQUIRED_STATUS,
-    maxAgeSec: 900
-  };
-
-  if (!receipt) {
-    return {
-      ok: false,
-      challenge: receiptChallenge(action, 'No EMILIA receipt presented.', challengeOpts)
-    };
-  }
-
-  // NOTE: allowInlineKey accepts the receipt's own key (proves integrity, not
-  // trust). In production, pin trustedKeys to the issuers you trust and drop
-  // allowInlineKey.
-  const verified: VerifyResult = verifyEmiliaReceipt(receipt, {
-    allowInlineKey: true,
-    action,
-    maxAgeSec: 900
+/**
+ * Same semantics for a batch-row delete, bound to THIS exact table + set of rows.
+ * row ids are sorted numerically so the binding is order-independent: a receipt
+ * approving {3,5,9} authorizes exactly {3,5,9}, never a different set.
+ */
+export async function runBatchDeleteRowsGuarded(
+  tableId: number | string,
+  rowIds: ReadonlyArray<number | string>,
+  receipt: unknown,
+  fn: () => Promise<void>
+): Promise<RunResult> {
+  const gate = await getGate('batch_delete_rows', (t: {
+    tableId: unknown;
+    rowIds: ReadonlyArray<number | string>;
+  }) => {
+    const sorted = [...t.rowIds].map(Number).sort((a, b) => a - b);
+    return `baserow.rows.batch_delete:${t.tableId}:${sorted.join(',')}`;
   });
-
-  if (!verified.ok || !verified.receipt_id) {
-    return {
-      ok: false,
-      challenge: {
-        ...receiptChallenge(action, `Receipt rejected: ${verified.reason}.`, challengeOpts),
-        // Sanitized: never echo the full verified object (signer/subject/detail).
-        rejected: { reason: verified.reason ?? 'receipt_invalid' }
-      }
-    };
-  }
-
-  if (consumedReceiptIds.has(verified.receipt_id)) {
-    return {
-      ok: false,
-      challenge: {
-        ...receiptChallenge(action, 'Receipt already consumed (replay refused).', challengeOpts),
-        rejected: { reason: 'receipt_replayed' }
-      }
-    };
-  }
-
-  const receiptId = verified.receipt_id;
-  return {
-    ok: true,
-    receiptId,
-    // Consume-after-success: the caller commits ONLY after the irreversible
-    // action succeeds. Idempotent — a double-commit is a no-op.
-    commit: () => {
-      consumedReceiptIds.add(receiptId);
-    }
-  };
+  return gate.run(receipt, { target: { tableId, rowIds } }, fn);
 }

--- a/src/receipt-guard.ts
+++ b/src/receipt-guard.ts
@@ -24,16 +24,26 @@ function loadModule(): Promise<RequireReceiptModule> {
 const consumedReceiptIds = new Set<string>();
 
 export type GuardResult =
-  | { ok: true; receiptId: string }
+  | { ok: true; receiptId: string; commit: () => void }
   | { ok: false; challenge: Record<string, unknown> };
 
 /**
  * Demand a verifiable EMILIA authorization receipt before an irreversible action.
  *
- * Returns the receipt id to record on success, or a machine-readable
- * Receipt Required challenge (HTTP 428 shape) the agent can act on — the MCP
- * tool-result equivalent of answering 428. This is portable accountability
- * evidence the service keeps for its own liability; it is not auth or permissions.
+ * On success, returns the receipt id PLUS a `commit()` callback. The receipt is
+ * NOT marked consumed until the caller invokes `commit()` — which the caller MUST
+ * do only AFTER the irreversible action has actually succeeded. If the action
+ * throws, `commit()` is never called and the approval stays retryable (it was
+ * never spent on a delete that didn't happen). Replay protection is enforced at
+ * verify time (not-already-consumed check below), so a receipt can never drive
+ * two deletes even before commit.
+ *
+ * On failure, returns a machine-readable Receipt Required challenge (HTTP 428
+ * shape) the agent can act on — the MCP tool-result equivalent of answering 428.
+ * Rejection detail is sanitized to a minimal `{ rejected: { reason } }` shape so
+ * no signer, subject, or library internals leak to the caller. This is portable
+ * accountability evidence the service keeps for its own liability; it is not auth
+ * or permissions.
  */
 export async function guardReceipt(
   action: string,
@@ -68,7 +78,8 @@ export async function guardReceipt(
       ok: false,
       challenge: {
         ...receiptChallenge(action, `Receipt rejected: ${verified.reason}.`, challengeOpts),
-        rejected: verified
+        // Sanitized: never echo the full verified object (signer/subject/detail).
+        rejected: { reason: verified.reason ?? 'receipt_invalid' }
       }
     };
   }
@@ -78,11 +89,19 @@ export async function guardReceipt(
       ok: false,
       challenge: {
         ...receiptChallenge(action, 'Receipt already consumed (replay refused).', challengeOpts),
-        rejected: { ok: false, reason: 'receipt_replayed' }
+        rejected: { reason: 'receipt_replayed' }
       }
     };
   }
 
-  consumedReceiptIds.add(verified.receipt_id);
-  return { ok: true, receiptId: verified.receipt_id };
+  const receiptId = verified.receipt_id;
+  return {
+    ok: true,
+    receiptId,
+    // Consume-after-success: the caller commits ONLY after the irreversible
+    // action succeeds. Idempotent — a double-commit is a no-op.
+    commit: () => {
+      consumedReceiptIds.add(receiptId);
+    }
+  };
 }

--- a/src/receipt-guard.ts
+++ b/src/receipt-guard.ts
@@ -1,0 +1,88 @@
+import type {
+  VerifyResult,
+  ChallengeOptions
+} from '@emilia-protocol/require-receipt';
+
+// @emilia-protocol/require-receipt is ESM-only while this server compiles to
+// CommonJS, so load it via a real dynamic import() that tsc won't downlevel to
+// require(). Cache the module after the first load.
+type RequireReceiptModule = typeof import('@emilia-protocol/require-receipt');
+const dynamicImport = new Function(
+  'specifier',
+  'return import(specifier)'
+) as (specifier: string) => Promise<RequireReceiptModule>;
+
+let modulePromise: Promise<RequireReceiptModule> | undefined;
+function loadModule(): Promise<RequireReceiptModule> {
+  if (!modulePromise) {
+    modulePromise = dynamicImport('@emilia-protocol/require-receipt');
+  }
+  return modulePromise;
+}
+
+// One-time consumption: receipt_ids consumed by this process cannot be replayed.
+const consumedReceiptIds = new Set<string>();
+
+export type GuardResult =
+  | { ok: true; receiptId: string }
+  | { ok: false; challenge: Record<string, unknown> };
+
+/**
+ * Demand a verifiable EMILIA authorization receipt before an irreversible action.
+ *
+ * Returns the receipt id to record on success, or a machine-readable
+ * Receipt Required challenge (HTTP 428 shape) the agent can act on — the MCP
+ * tool-result equivalent of answering 428. This is portable accountability
+ * evidence the service keeps for its own liability; it is not auth or permissions.
+ */
+export async function guardReceipt(
+  action: string,
+  receipt: unknown
+): Promise<GuardResult> {
+  const { verifyEmiliaReceipt, receiptChallenge, RECEIPT_REQUIRED_STATUS } =
+    await loadModule();
+
+  const challengeOpts: ChallengeOptions = {
+    status: RECEIPT_REQUIRED_STATUS,
+    maxAgeSec: 900
+  };
+
+  if (!receipt) {
+    return {
+      ok: false,
+      challenge: receiptChallenge(action, 'No EMILIA receipt presented.', challengeOpts)
+    };
+  }
+
+  // NOTE: allowInlineKey accepts the receipt's own key (proves integrity, not
+  // trust). In production, pin trustedKeys to the issuers you trust and drop
+  // allowInlineKey.
+  const verified: VerifyResult = verifyEmiliaReceipt(receipt, {
+    allowInlineKey: true,
+    action,
+    maxAgeSec: 900
+  });
+
+  if (!verified.ok || !verified.receipt_id) {
+    return {
+      ok: false,
+      challenge: {
+        ...receiptChallenge(action, `Receipt rejected: ${verified.reason}.`, challengeOpts),
+        rejected: verified
+      }
+    };
+  }
+
+  if (consumedReceiptIds.has(verified.receipt_id)) {
+    return {
+      ok: false,
+      challenge: {
+        ...receiptChallenge(action, 'Receipt already consumed (replay refused).', challengeOpts),
+        rejected: { ok: false, reason: 'receipt_replayed' }
+      }
+    };
+  }
+
+  consumedReceiptIds.add(verified.receipt_id);
+  return { ok: true, receiptId: verified.receipt_id };
+}

--- a/src/tools/row.ts
+++ b/src/tools/row.ts
@@ -1,5 +1,17 @@
 import { BaserowClient } from '../baserow-client.js';
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { guardReceipt } from '../receipt-guard.js';
+
+// Reusable schema for the EMILIA authorization receipt carried as a tool argument
+// (the MCP stdio equivalent of an HTTP receipt header). Optional in the schema so
+// a missing receipt returns a structured Receipt Required challenge rather than a
+// schema validation error.
+const authorizationReceiptSchema = {
+  type: 'object',
+  description:
+    'An EMILIA authorization receipt proving a named human approved this exact deletion. Required to execute.',
+  additionalProperties: true
+} as const;
 
 export function getRowToolSchemas(): Tool[] {
   return [
@@ -106,7 +118,8 @@ export function getRowToolSchemas(): Tool[] {
           row_id: {
             type: 'number',
             description: 'The ID of the row to delete'
-          }
+          },
+          authorization_receipt: authorizationReceiptSchema
         },
         required: ['table_id', 'row_id']
       }
@@ -178,7 +191,8 @@ export function getRowToolSchemas(): Tool[] {
             items: {
               type: 'number'
             }
-          }
+          },
+          authorization_receipt: authorizationReceiptSchema
         },
         required: ['table_id', 'row_ids']
       }
@@ -234,16 +248,23 @@ export async function handleRowTools(
       });
       break;
 
-    case 'baserow_delete_row':
+    case 'baserow_delete_row': {
       if (!args?.table_id || !args?.row_id) {
         throw new Error('table_id and row_id are required');
+      }
+      const guard = await guardReceipt('baserow.row.delete', args?.authorization_receipt);
+      if (!guard.ok) {
+        result = guard.challenge;
+        break;
       }
       await client.deleteRow(args.table_id, args.row_id);
       result = {
         success: true,
-        message: `Row ${args.row_id} deleted successfully`
+        message: `Row ${args.row_id} deleted successfully`,
+        authorization_receipt_id: guard.receiptId
       };
       break;
+    }
 
     case 'baserow_batch_create_rows':
       if (!args?.table_id || !args?.rows || !Array.isArray(args.rows)) {
@@ -265,9 +286,14 @@ export async function handleRowTools(
       });
       break;
 
-    case 'baserow_batch_delete_rows':
+    case 'baserow_batch_delete_rows': {
       if (!args?.table_id || !args?.row_ids || !Array.isArray(args.row_ids)) {
         throw new Error('table_id and row_ids array are required');
+      }
+      const guard = await guardReceipt('baserow.rows.batch_delete', args?.authorization_receipt);
+      if (!guard.ok) {
+        result = guard.challenge;
+        break;
       }
       await client.batchDeleteRows({
         table_id: args.table_id,
@@ -275,9 +301,11 @@ export async function handleRowTools(
       });
       result = {
         success: true,
-        message: `${args.row_ids.length} rows deleted successfully`
+        message: `${args.row_ids.length} rows deleted successfully`,
+        authorization_receipt_id: guard.receiptId
       };
       break;
+    }
 
     default:
       throw new Error(`Unknown row tool: ${toolName}`);

--- a/src/tools/row.ts
+++ b/src/tools/row.ts
@@ -1,6 +1,6 @@
 import { BaserowClient } from '../baserow-client.js';
 import { Tool } from '@modelcontextprotocol/sdk/types.js';
-import { guardReceipt } from '../receipt-guard.js';
+import { runDeleteRowGuarded, runBatchDeleteRowsGuarded } from '../receipt-guard.js';
 
 // Reusable schema for the EMILIA authorization receipt carried as a tool argument
 // (the MCP stdio equivalent of an HTTP receipt header). Optional in the schema so
@@ -253,19 +253,19 @@ export async function handleRowTools(
         throw new Error('table_id and row_id are required');
       }
       // Bind the receipt to THIS exact row, not just "a delete": a receipt
-      // approving baserow.row.delete:5:11 cannot delete row 99 in table 5.
-      const guard = await guardReceipt(
-        `baserow.row.delete:${args.table_id}:${args.row_id}`,
-        args?.authorization_receipt
+      // approving baserow.row.delete:5:11 cannot delete row 99 in table 5. The
+      // gate verifies+reserves, runs the delete, then consumes the receipt only
+      // AFTER it succeeds (failure releases it, keeping the approval retryable).
+      const guard = await runDeleteRowGuarded(
+        args.table_id,
+        args.row_id,
+        args?.authorization_receipt,
+        () => client.deleteRow(args.table_id, args.row_id)
       );
       if (!guard.ok) {
-        result = guard.challenge;
+        result = guard.body;
         break;
       }
-      await client.deleteRow(args.table_id, args.row_id);
-      // Consume the receipt only AFTER the delete succeeds; if deleteRow threw,
-      // commit is never reached and the approval stays retryable.
-      guard.commit();
       result = {
         success: true,
         message: `Row ${args.row_id} deleted successfully`,
@@ -298,26 +298,25 @@ export async function handleRowTools(
       if (!args?.table_id || !args?.row_ids || !Array.isArray(args.row_ids)) {
         throw new Error('table_id and row_ids array are required');
       }
-      // Bind the receipt to THIS exact table + set of rows. row_ids are sorted
-      // numerically so the binding is order-independent: a receipt approving
-      // {3,5,9} authorizes exactly {3,5,9}, never a different set.
-      const sortedRowIds = [...args.row_ids]
-        .map((id: unknown) => Number(id))
-        .sort((a, b) => a - b);
-      const guard = await guardReceipt(
-        `baserow.rows.batch_delete:${args.table_id}:${sortedRowIds.join(',')}`,
-        args?.authorization_receipt
+      // Bind the receipt to THIS exact table + set of rows. The gate folds the
+      // numerically-sorted row ids into the bound action so the binding is
+      // order-independent: a receipt approving {3,5,9} authorizes exactly
+      // {3,5,9}, never a different set. Consume-after-success / replay refusal /
+      // sanitized rejection all come from the gate.
+      const guard = await runBatchDeleteRowsGuarded(
+        args.table_id,
+        args.row_ids,
+        args?.authorization_receipt,
+        () =>
+          client.batchDeleteRows({
+            table_id: args.table_id,
+            row_ids: args.row_ids
+          })
       );
       if (!guard.ok) {
-        result = guard.challenge;
+        result = guard.body;
         break;
       }
-      await client.batchDeleteRows({
-        table_id: args.table_id,
-        row_ids: args.row_ids
-      });
-      // Consume the receipt only AFTER the batch delete succeeds.
-      guard.commit();
       result = {
         success: true,
         message: `${args.row_ids.length} rows deleted successfully`,

--- a/src/tools/row.ts
+++ b/src/tools/row.ts
@@ -252,12 +252,20 @@ export async function handleRowTools(
       if (!args?.table_id || !args?.row_id) {
         throw new Error('table_id and row_id are required');
       }
-      const guard = await guardReceipt('baserow.row.delete', args?.authorization_receipt);
+      // Bind the receipt to THIS exact row, not just "a delete": a receipt
+      // approving baserow.row.delete:5:11 cannot delete row 99 in table 5.
+      const guard = await guardReceipt(
+        `baserow.row.delete:${args.table_id}:${args.row_id}`,
+        args?.authorization_receipt
+      );
       if (!guard.ok) {
         result = guard.challenge;
         break;
       }
       await client.deleteRow(args.table_id, args.row_id);
+      // Consume the receipt only AFTER the delete succeeds; if deleteRow threw,
+      // commit is never reached and the approval stays retryable.
+      guard.commit();
       result = {
         success: true,
         message: `Row ${args.row_id} deleted successfully`,
@@ -290,7 +298,16 @@ export async function handleRowTools(
       if (!args?.table_id || !args?.row_ids || !Array.isArray(args.row_ids)) {
         throw new Error('table_id and row_ids array are required');
       }
-      const guard = await guardReceipt('baserow.rows.batch_delete', args?.authorization_receipt);
+      // Bind the receipt to THIS exact table + set of rows. row_ids are sorted
+      // numerically so the binding is order-independent: a receipt approving
+      // {3,5,9} authorizes exactly {3,5,9}, never a different set.
+      const sortedRowIds = [...args.row_ids]
+        .map((id: unknown) => Number(id))
+        .sort((a, b) => a - b);
+      const guard = await guardReceipt(
+        `baserow.rows.batch_delete:${args.table_id}:${sortedRowIds.join(',')}`,
+        args?.authorization_receipt
+      );
       if (!guard.ok) {
         result = guard.challenge;
         break;
@@ -299,6 +316,8 @@ export async function handleRowTools(
         table_id: args.table_id,
         row_ids: args.row_ids
       });
+      // Consume the receipt only AFTER the batch delete succeeds.
+      guard.commit();
       result = {
         success: true,
         message: `${args.row_ids.length} rows deleted successfully`,

--- a/src/types/require-receipt.d.ts
+++ b/src/types/require-receipt.d.ts
@@ -1,45 +1,51 @@
-// Minimal local type declarations for @emilia-protocol/require-receipt (^0.3.0).
-// The published package ships no .d.ts, so we declare only the surface we use.
-// See: https://www.emiliaprotocol.ai/agent-guard
+// Minimal local type declarations for @emilia-protocol/require-receipt (^0.4.0).
+// The published package ships no .d.ts, so we declare only the surface we use:
+// the canonical hardened gate. See: https://www.emiliaprotocol.ai/agent-guard
 
 declare module '@emilia-protocol/require-receipt' {
-  export const RECEIPT_REQUIRED_STATUS: number;
-
-  export interface VerifyOptions {
-    /** base64url SPKI-DER public keys you trust as issuers */
+  /** Options for the canonical hardened gate (makeReceiptGate). */
+  export interface ReceiptGateOptions {
+    /** base action_type, or a fn deriving the fully-bound action from the target */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    action: string | ((target: any) => string);
+    /** base64url SPKI-DER issuer keys you trust (recommended in production) */
     trustedKeys?: string[];
     /** also accept the receipt's own inline key (proves integrity, NOT trust) */
     allowInlineKey?: boolean;
-    /** require the receipt to be bound to this action_type */
-    action?: string | null;
-    /** reject receipts older than this (seconds) */
     maxAgeSec?: number;
-    /** acceptable claim.outcome values */
     allowedOutcomes?: string[];
-  }
-
-  export interface VerifyResult {
-    ok: boolean;
-    reason?: string;
-    outcome?: string;
-    subject?: string;
-    receipt_id?: string;
-    signer?: string;
-    detail?: string;
-  }
-
-  export interface ChallengeOptions {
-    status?: number;
     statusCode?: number;
-    maxAgeSec?: number;
-    [key: string]: unknown;
+    manifestUrl?: string;
+    assuranceClass?: string;
+    /** consumed-receipt store; defaults to in-memory (process-local) */
+    store?: { has: (id: string) => boolean; add: (id: string) => void };
   }
 
-  export function verifyEmiliaReceipt(doc: unknown, opts?: VerifyOptions): VerifyResult;
+  /** The resource the receipt must be bound to. */
+  export interface GateContext {
+    target?: unknown;
+  }
 
-  export function receiptChallenge(
-    action: string | null,
-    reason?: string,
-    opts?: ChallengeOptions
-  ): Record<string, unknown>;
+  /** Verify+reserve result from gate.check (ok), else a Receipt Required 428 body. */
+  export type CheckResult =
+    | { ok: true; receiptId: string; outcome?: string; signer?: string; subject?: string; boundAction: string }
+    | { ok: false; status: number; body: Record<string, unknown> };
+
+  /** Result of gate.run: ok carries the fn result; rejection carries the 428 body. */
+  export type RunResult<T = unknown> =
+    | { ok: true; receiptId: string; outcome?: string; signer?: string; result: T }
+    | { ok: false; status: number; body: Record<string, unknown> };
+
+  /** The hardened Receipt-Required gate returned by makeReceiptGate. */
+  export interface ReceiptGate {
+    check(receipt: unknown, ctx?: GateContext): CheckResult;
+    commit(receiptId: string): void;
+    release(receiptId: string): void;
+    run<T = unknown>(receipt: unknown, ctx: GateContext, fn: () => Promise<T> | T): Promise<RunResult<T>>;
+    run<T = unknown>(receipt: unknown, fn: () => Promise<T> | T): Promise<RunResult<T>>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    boundActionFor(target: any): string;
+  }
+
+  export function makeReceiptGate(opts: ReceiptGateOptions): ReceiptGate;
 }

--- a/src/types/require-receipt.d.ts
+++ b/src/types/require-receipt.d.ts
@@ -1,0 +1,45 @@
+// Minimal local type declarations for @emilia-protocol/require-receipt (^0.3.0).
+// The published package ships no .d.ts, so we declare only the surface we use.
+// See: https://www.emiliaprotocol.ai/agent-guard
+
+declare module '@emilia-protocol/require-receipt' {
+  export const RECEIPT_REQUIRED_STATUS: number;
+
+  export interface VerifyOptions {
+    /** base64url SPKI-DER public keys you trust as issuers */
+    trustedKeys?: string[];
+    /** also accept the receipt's own inline key (proves integrity, NOT trust) */
+    allowInlineKey?: boolean;
+    /** require the receipt to be bound to this action_type */
+    action?: string | null;
+    /** reject receipts older than this (seconds) */
+    maxAgeSec?: number;
+    /** acceptable claim.outcome values */
+    allowedOutcomes?: string[];
+  }
+
+  export interface VerifyResult {
+    ok: boolean;
+    reason?: string;
+    outcome?: string;
+    subject?: string;
+    receipt_id?: string;
+    signer?: string;
+    detail?: string;
+  }
+
+  export interface ChallengeOptions {
+    status?: number;
+    statusCode?: number;
+    maxAgeSec?: number;
+    [key: string]: unknown;
+  }
+
+  export function verifyEmiliaReceipt(doc: unknown, opts?: VerifyOptions): VerifyResult;
+
+  export function receiptChallenge(
+    action: string | null,
+    reason?: string,
+    opts?: ChallengeOptions
+  ): Record<string, unknown>;
+}


### PR DESCRIPTION
This PR adds an optional Receipt Required guard around destructive Baserow row deletion tools. Missing receipt returns 428, a valid receipt allows deletion, replay is refused, and tampering is refused. It is intentionally scoped to `delete_row` and `batch_delete_rows`, with tests proving no delete happens without a valid receipt.

### What it does

Before `baserow_delete_row` or `baserow_batch_delete_rows` executes, the call must carry an `authorization_receipt` — a verifiable EP-RECEIPT-v1 proving a named human accountably approved *this exact* deletion. No receipt → the tool returns a structured Receipt-Required challenge (HTTP 428 shape) telling the agent exactly what to bring, instead of silently deleting. A well-behaved agent obtains one and retries.

### What this is — and isn't

Not auth ("who are you") and not permissions ("are you allowed here"). It is portable accountability evidence the operator keeps for their own liability — necessary, not sufficient. It sits alongside your Baserow tokens/scopes for the destructive path; it does not replace them.

### Footprint

- No backend, no network — verification is offline Ed25519 over canonical JSON.
- One dependency: `@emilia-protocol/require-receipt` (Apache-2.0).
- The other six tools are untouched. The receipt arg is **optional** in the schema, so the missing-receipt path returns the challenge rather than a schema error.

### Conformance (RR-1), proven against the real handler

1. missing receipt → challenge, **no delete**
2. valid action-bound receipt → delete runs
3. same receipt replayed → refused (one-time consumption)
4. tampered receipt → refused

### Implementation note

`@emilia-protocol/require-receipt` is ESM-only, while this project emits CommonJS, so the guard preserves dynamic import through TypeScript output. Happy to adjust if you prefer an `.mjs` boundary or tsconfig change.

### Production note

The guard currently passes `allowInlineKey: true`, which proves a receipt's integrity but not issuer trust. For production, pin `trustedKeys` to the issuers you trust and drop `allowInlineKey`. The consumed-receipt set is in-memory (per process); back it with shared storage if you run multiple instances.

---

Format and semantics track `draft-schrock-ep-authorization-receipts`, an individual IETF Internet-Draft (not an RFC, no IETF consensus implied). Happy to adjust scope, naming, or the import boundary to fit the project's conventions.
